### PR TITLE
Implement my page backend endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # Tudy
+
+This project provides a simple study management API. After starting the Spring Boot application,
+Swagger UI is available at `/swagger-ui/index.html` for exploring the API endpoints.

--- a/backend/Tudy/build.gradle
+++ b/backend/Tudy/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     compileOnly 'org.projectlombok:lombok:1.18.26'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/backend/Tudy/src/main/java/com/example/tudy/auth/AuthController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/auth/AuthController.java
@@ -1,0 +1,21 @@
+package com.example.tudy.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String auth) {
+        authService.logout(auth);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/Tudy/src/main/java/com/example/tudy/auth/AuthService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/auth/AuthService.java
@@ -1,0 +1,45 @@
+package com.example.tudy.auth;
+
+import com.example.tudy.user.User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class AuthService {
+    private final Map<String, Long> tokens = new ConcurrentHashMap<>();
+    private final Set<String> blacklist = ConcurrentHashMap.newKeySet();
+
+    public String generateToken(User user) {
+        String token = UUID.randomUUID().toString();
+        tokens.put(token, user.getId());
+        return token;
+    }
+
+    public Long verify(String header) {
+        if (header == null || !header.startsWith("Bearer ")) {
+            throw new RuntimeException("Unauthorized");
+        }
+        String token = header.substring(7);
+        if (blacklist.contains(token)) {
+            throw new RuntimeException("Unauthorized");
+        }
+        Long id = tokens.get(token);
+        if (id == null) {
+            throw new RuntimeException("Unauthorized");
+        }
+        return id;
+    }
+
+    public void logout(String header) {
+        if (header == null || !header.startsWith("Bearer ")) {
+            return;
+        }
+        String token = header.substring(7);
+        blacklist.add(token);
+        tokens.remove(token);
+    }
+}

--- a/backend/Tudy/src/main/java/com/example/tudy/group/GroupController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/group/GroupController.java
@@ -4,12 +4,27 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/groups")
 @RequiredArgsConstructor
 public class GroupController {
     private final GroupService groupService;
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> list(@RequestParam("public") boolean isPublic,
+                                                    @RequestParam(required = false) String password,
+                                                    @RequestParam(defaultValue = "0") int page,
+                                                    @RequestParam(defaultValue = "10") int size) {
+        var result = groupService.search(isPublic, password, org.springframework.data.domain.PageRequest.of(page, size));
+        return ResponseEntity.ok(Map.of(
+                "content", result.getContent(),
+                "page", result.getNumber(),
+                "size", result.getSize(),
+                "totalElements", result.getTotalElements()
+        ));
+    }
 
     @PostMapping
     public ResponseEntity<Group> create(@RequestBody GroupRequest req) {

--- a/backend/Tudy/src/main/java/com/example/tudy/group/GroupRepository.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/group/GroupRepository.java
@@ -1,6 +1,10 @@
 package com.example.tudy.group;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
-} 
+    Page<Group> findByPasswordIsNull(Pageable pageable);
+    Page<Group> findByPassword(String password, Pageable pageable);
+}

--- a/backend/Tudy/src/main/java/com/example/tudy/group/GroupService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/group/GroupService.java
@@ -13,6 +13,17 @@ public class GroupService {
     private final UserRepository userRepository;
     private final GroupMemberRepository groupMemberRepository;
 
+    public org.springframework.data.domain.Page<Group> search(boolean isPublic, String password, org.springframework.data.domain.Pageable pageable) {
+        if (isPublic) {
+            return groupRepository.findByPasswordIsNull(pageable);
+        } else {
+            if (password == null) {
+                throw new IllegalArgumentException("password required");
+            }
+            return groupRepository.findByPassword(password, pageable);
+        }
+    }
+
     public Group createGroup(String name, String password) {
         Group group = new Group();
         group.setName(name);

--- a/backend/Tudy/src/main/java/com/example/tudy/user/User.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/user/User.java
@@ -25,6 +25,8 @@ public class User {
 
     private String major;
 
+    private String college;
+
     private String profileImage;
 
     private Integer coinBalance = 0;

--- a/backend/Tudy/src/main/java/com/example/tudy/user/UserController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/user/UserController.java
@@ -2,6 +2,7 @@ package com.example.tudy.user;
 
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import com.example.tudy.auth.AuthService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,6 +13,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final AuthService authService;
 
     @PostMapping("/signup")
     public ResponseEntity<User> signUp(@RequestBody SignUpRequest request) {
@@ -22,8 +24,8 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<Map<String, String>> login(@RequestBody LoginRequest request) {
         return userService.login(request.getEmail(), request.getPassword())
-                .map(u -> ResponseEntity.ok(Map.of("status", "success")))
-                .orElseGet(() -> ResponseEntity.status(401).body(Map.of("status", "fail")));
+                .map(u -> ResponseEntity.ok(Map.of("token", authService.generateToken(u))))
+                .orElseGet(() -> ResponseEntity.status(401).body(Map.of("error", "Invalid credentials")));
     }
 
     @PutMapping("/{id}/nickname")
@@ -42,6 +44,44 @@ public class UserController {
     public ResponseEntity<Void> changeProfileImage(@PathVariable Long id, @RequestBody ProfileImageRequest request) {
         userService.updateProfileImage(id, request.getImagePath());
         return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{id}/email")
+    public ResponseEntity<?> changeEmail(@PathVariable Long id, @RequestBody EmailRequest request,
+                                         @RequestHeader("Authorization") String auth) {
+        Long userId = authService.verify(auth);
+        if (!userId.equals(id)) {
+            return ResponseEntity.status(403).build();
+        }
+        if (request.getEmail() == null || !request.getEmail().contains("@")) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid email"));
+        }
+        try {
+            User user = userService.updateEmail(id, request.getEmail());
+            return ResponseEntity.ok(user);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(409).body(Map.of("error", "Email already exists"));
+        }
+    }
+
+    @PutMapping("/{id}/major")
+    public ResponseEntity<User> changeMajor(@PathVariable Long id, @RequestBody ValueRequest request,
+                                            @RequestHeader("Authorization") String auth) {
+        Long userId = authService.verify(auth);
+        if (!userId.equals(id)) {
+            return ResponseEntity.status(403).build();
+        }
+        return ResponseEntity.ok(userService.updateMajor(id, request.getValue()));
+    }
+
+    @PutMapping("/{id}/college")
+    public ResponseEntity<User> changeCollege(@PathVariable Long id, @RequestBody ValueRequest request,
+                                              @RequestHeader("Authorization") String auth) {
+        Long userId = authService.verify(auth);
+        if (!userId.equals(id)) {
+            return ResponseEntity.status(403).build();
+        }
+        return ResponseEntity.ok(userService.updateCollege(id, request.getValue()));
     }
 
     @Data
@@ -72,5 +112,15 @@ public class UserController {
     @Data
     private static class ProfileImageRequest {
         private String imagePath;
+    }
+
+    @Data
+    private static class EmailRequest {
+        private String email;
+    }
+
+    @Data
+    private static class ValueRequest {
+        private String value;
     }
 }

--- a/backend/Tudy/src/main/java/com/example/tudy/user/UserService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/user/UserService.java
@@ -21,6 +21,7 @@ public class UserService {
         user.setPasswordHash(passwordEncoder.encode(password));
         user.setNickname(nickname);
         user.setMajor(major);
+        user.setCollege(null);
         user.setCoinBalance(0);
         return userRepository.save(user);
     }
@@ -49,6 +50,27 @@ public class UserService {
         User user = userRepository.findById(userId).orElseThrow();
         user.setProfileImage(imagePath);
         userRepository.save(user);
+    }
+
+    public User updateEmail(Long userId, String email) {
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new IllegalArgumentException("Email already exists");
+        }
+        User user = userRepository.findById(userId).orElseThrow();
+        user.setEmail(email);
+        return userRepository.save(user);
+    }
+
+    public User updateMajor(Long userId, String major) {
+        User user = userRepository.findById(userId).orElseThrow();
+        user.setMajor(major);
+        return userRepository.save(user);
+    }
+
+    public User updateCollege(Long userId, String college) {
+        User user = userRepository.findById(userId).orElseThrow();
+        user.setCollege(college);
+        return userRepository.save(user);
     }
 
         public void addCoins(Long userId, int amount) {

--- a/backend/Tudy/src/main/resources/schema.sql
+++ b/backend/Tudy/src/main/resources/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE users (
   nickname VARCHAR,
   college_id INTEGER REFERENCES colleges(id),
   major VARCHAR,
+  college VARCHAR,
   profile_image VARCHAR,
   coin_balance INTEGER DEFAULT 0,
   created_at TIMESTAMP DEFAULT now()

--- a/backend/Tudy/src/test/java/com/example/tudy/integration/UserApiTests.java
+++ b/backend/Tudy/src/test/java/com/example/tudy/integration/UserApiTests.java
@@ -1,0 +1,71 @@
+package com.example.tudy.integration;
+
+import com.example.tudy.user.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserApiTests {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    UserService userService;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    private String login(String email, String password) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/users/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\""+email+"\",\"password\":\""+password+"\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    @Test
+    void changeEmailSuccess() throws Exception {
+        var u = userService.signUp("a@a.com","pw","n","CS");
+        String token = login("a@a.com","pw");
+        mockMvc.perform(put("/api/users/"+u.getId()+"/email")
+                        .header("Authorization","Bearer "+token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"b@b.com\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("b@b.com"));
+    }
+
+    @Test
+    void changeEmailForbidden() throws Exception {
+        var u1 = userService.signUp("c@c.com","pw","n","CS");
+        var u2 = userService.signUp("d@d.com","pw","n","CS");
+        String token = login("d@d.com","pw");
+        mockMvc.perform(put("/api/users/"+u1.getId()+"/email")
+                        .header("Authorization","Bearer "+token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"x@x.com\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void changeEmailConflict() throws Exception {
+        var u1 = userService.signUp("e@e.com","pw","n","CS");
+        userService.signUp("f@f.com","pw","n","CS");
+        String token = login("e@e.com","pw");
+        mockMvc.perform(put("/api/users/"+u1.getId()+"/email")
+                        .header("Authorization","Bearer "+token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"f@f.com\"}"))
+                .andExpect(status().isConflict());
+    }
+}


### PR DESCRIPTION
## Summary
- add Swagger OpenAPI dependency
- store college information for users
- implement token-based auth service and logout endpoint
- implement email update, major/college update APIs
- support group search by public/private option
- provide basic integration tests and Swagger docs

## Testing
- `./gradlew test` *(fails: Unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_6874fe4092308322aa77a9c0112e8e36