### PR TITLE
Fix FriendshipRepository method naming

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/friend/FriendshipRepository.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/friend/FriendshipRepository.java
@@ -6,7 +6,7 @@ import java.util.List;
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     List<Friendship> findByToUser_IdAndStatus(Long toUserId, Friendship.Status status);
     List<Friendship> findByFromUserIdAndStatus(Long fromUserId, Friendship.Status status);
-    List<Friendship> findByFromUserIdOrToUserIdAndStatus(String fromUserId, String toUserId, Friendship.Status status);
+    List<Friendship> findByFromUser_IdOrToUser_IdAndStatus(Long fromUserId, Long toUserId, Friendship.Status status);
     List<Friendship> findByFromUserIdOrToUserId(Long fromUserId, Long toUserId);
     boolean existsByFromUserIdAndToUserIdAndStatus(Long fromUserId, Long toUserId, Friendship.Status status);
     Friendship findByFromUserIdAndToUserIdAndStatus(Long fromUserId, Long toUserId, Friendship.Status status);

--- a/backend/Tudy/src/main/java/com/example/tudy/friend/FriendshipService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/friend/FriendshipService.java
@@ -65,9 +65,14 @@ public class FriendshipService {
     }
 
     public List<User> getFriends(String userId) {
-        List<Friendship> friendships = friendshipRepository.findByFromUserIdOrToUserIdAndStatus(userId, userId, Friendship.Status.ACCEPTED);
+        Optional<User> userOpt = userRepository.findByUserId(userId);
+        if (userOpt.isEmpty()) {
+            return List.of();
+        }
+        Long id = userOpt.get().getId();
+        List<Friendship> friendships = friendshipRepository.findByFromUser_IdOrToUser_IdAndStatus(id, id, Friendship.Status.ACCEPTED);
         return friendships.stream().map(f -> {
-            if (f.getFromUser().getId().equals(userId)) return f.getToUser();
+            if (f.getFromUser().getId().equals(id)) return f.getToUser();
             else return f.getFromUser();
         }).toList();
     }


### PR DESCRIPTION
## Summary
- rename `findByFromUserIdOrToUserIdAndStatus` to `findByFromUser_IdOrToUser_IdAndStatus`
- update parameter types to `Long`
- adjust FriendshipService to use the new repository method

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68888dede44083228cae7466a9b42f65