### PR TITLE
Fix GroupJoinRequest createdAt query issue

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/group/GroupJoinRequest.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/group/GroupJoinRequest.java
@@ -4,6 +4,7 @@ import com.example.tudy.user.User;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -22,12 +23,15 @@ public class GroupJoinRequest {
     @JoinColumn(name = "group_id")
     private Group group;
 
+    private LocalDateTime createdAt;
+
     @Enumerated(EnumType.STRING)
     private RequestStatus status = RequestStatus.PENDING;
 
     public GroupJoinRequest(User user, Group group) {
         this.user = user;
         this.group = group;
+        this.createdAt = LocalDateTime.now();
     }
 
     public enum RequestStatus {


### PR DESCRIPTION
## Summary
- add `createdAt` timestamp field to `GroupJoinRequest`
- initialize timestamp when creating the request

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68889119a7fc8322a3508a50c3ccf5a3