### PR TITLE
Use string userId for goal and friend queries

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/category/CategoryController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/category/CategoryController.java
@@ -62,7 +62,7 @@ public class CategoryController {
 
     @Data
     private static class CategoryRequest {
-        @Schema(description = "User ID", example = "1")
+        @Schema(description = "User ID", example = "user1")
         private String userId;
         @Schema(description = "Category name", example = "공부")
         private String name;

--- a/backend/Tudy/src/main/java/com/example/tudy/friend/FriendshipService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/friend/FriendshipService.java
@@ -47,7 +47,7 @@ public class FriendshipService {
         Optional<Friendship> requestOpt = friendshipRepository.findById(requestId);
         if (requestOpt.isEmpty()) return false;
         Friendship request = requestOpt.get();
-        if (!request.getToUser().getId().equals(userId) || request.getStatus() != Friendship.Status.PENDING) return false;
+        if (!request.getToUser().getUserId().equals(userId) || request.getStatus() != Friendship.Status.PENDING) return false;
         request.setStatus(Friendship.Status.ACCEPTED);
         friendshipRepository.save(request);
         return true;
@@ -58,7 +58,7 @@ public class FriendshipService {
         Optional<Friendship> requestOpt = friendshipRepository.findById(requestId);
         if (requestOpt.isEmpty()) return false;
         Friendship request = requestOpt.get();
-        if (!request.getToUser().getId().equals(userId) || request.getStatus() != Friendship.Status.PENDING) return false;
+        if (!request.getToUser().getUserId().equals(userId) || request.getStatus() != Friendship.Status.PENDING) return false;
         request.setStatus(Friendship.Status.REJECTED);
         friendshipRepository.save(request);
         return true;

--- a/backend/Tudy/src/main/java/com/example/tudy/goal/GoalController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/goal/GoalController.java
@@ -46,7 +46,7 @@ public class GoalController {
     @GetMapping
     @Operation(summary = "List goals")
     @ApiResponse(responseCode = "200", description = "Goals listed")
-    public ResponseEntity<List<Goal>> list(@RequestParam Long userId, @RequestParam(required = false) String categoryName) {
+    public ResponseEntity<List<Goal>> list(@RequestParam String userId, @RequestParam(required = false) String categoryName) {
         return ResponseEntity.ok(goalService.listGoals(userId, categoryName));
     }
 
@@ -91,7 +91,7 @@ public class GoalController {
 
     @Data
     private static class GoalRequest {
-        @Schema(description = "User ID", example = "1")
+        @Schema(description = "User ID", example = "user1")
         private String userId;
         @Schema(description = "Goal title", example = "스터디 목표")
         private String title;

--- a/backend/Tudy/src/main/java/com/example/tudy/goal/GoalService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/goal/GoalService.java
@@ -46,7 +46,7 @@ public class GoalService {
         // 그룹 목표라면 그룹원 모두에게 동일 목표 생성
         if (Boolean.TRUE.equals(isGroupGoal) && groupId != null) {
             for (GroupMember member : groupMemberRepository.findAllByGroupId(groupId)) {
-                if (!member.getUser().getId().equals(userId)) {
+                if (!member.getUser().getId().equals(user.getId())) {
                     Category memberCategory = getOrCreateCategory(member.getUser(), categoryName);
                     Goal groupGoal = new Goal();
                     groupGoal.setUser(member.getUser());
@@ -144,8 +144,8 @@ public class GoalService {
                 .sum();
     }
 
-    public List<Goal> listGoals(Long userId, String categoryName) {
-        User user = userRepository.findById(userId).orElseThrow();
+    public List<Goal> listGoals(String userId, String categoryName) {
+        User user = userRepository.findByUserId(userId).orElseThrow();
         if (categoryName == null) {
             return goalRepository.findByUser(user);
         } else {

--- a/backend/Tudy/src/test/java/com/example/tudy/category/CategoryApiTests.java
+++ b/backend/Tudy/src/test/java/com/example/tudy/category/CategoryApiTests.java
@@ -45,7 +45,7 @@ public class CategoryApiTests {
         int color = 2;
         // 카테고리 생성
         String reqJson = "{" +
-                "\"userId\":" + user.getId() + "," +
+                "\"userId\":\"" + user.getUserId() + "\"," +
                 "\"name\":\"" + name + "\"," +
                 "\"color\":2" +
                 "}";
@@ -56,14 +56,14 @@ public class CategoryApiTests {
                 .andExpect(jsonPath("$.name").value(name));
         // 중복 체크
         mockMvc.perform(get("/api/categories/exists")
-                .param("userId", user.getId().toString())
+                .param("userId", user.getUserId())
                 .param("name", name))
                 .andExpect(status().isOk())
                 .andExpect(content().string("true"));
         // 전체 목록
         mockMvc.perform(get("/api/categories")
-                .param("userId", user.getId().toString()))
+                .param("userId", user.getUserId()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value(name));
     }
-} 
+}

--- a/backend/Tudy/src/test/java/com/example/tudy/goal/GoalApiTests.java
+++ b/backend/Tudy/src/test/java/com/example/tudy/goal/GoalApiTests.java
@@ -51,7 +51,7 @@ public class GoalApiTests {
         String endDate = LocalDate.now().plusDays(7).toString();
         // 목표 생성
         String reqJson = "{" +
-                "\"userId\":" + user.getId() + "," +
+                "\"userId\":\"" + user.getUserId() + "\"," +
                 "\"title\":\"" + title + "\"," +
                 "\"categoryName\":\"" + categoryName + "\"," +
                 "\"startDate\":\"" + startDate + "\"," +
@@ -68,7 +68,7 @@ public class GoalApiTests {
                 .andExpect(jsonPath("$.title").value(title));
         // 카테고리명으로 조회
         mockMvc.perform(get("/api/goals")
-                .param("userId", user.getId().toString())
+                .param("userId", user.getUserId())
                 .param("categoryName", categoryName))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].title").value(title));
@@ -81,7 +81,7 @@ public class GoalApiTests {
                 "사진테스터", "2000.01.01", "컴퓨터공학", "공과대학", null, 0));
 
         String reqJson = "{" +
-                "\"userId\":" + user.getId() + "," +
+                "\"userId\":\"" + user.getUserId() + "\"," +
                 "\"title\":\"title\"," +
                 "\"categoryName\":\"cat\"," +
                 "\"startDate\":\"" + LocalDate.now() + "\"," +
@@ -111,7 +111,7 @@ public class GoalApiTests {
                 "시간테스터", "2000.01.01", "컴퓨터공학", "공과대학", null, 0));
 
         String reqJson = "{" +
-                "\"userId\":" + user.getId() + "," +
+                "\"userId\":\"" + user.getUserId() + "\"," +
                 "\"title\":\"title\"," +
                 "\"categoryName\":\"cat\"," +
                 "\"startDate\":\"" + LocalDate.now() + "\"," +

--- a/backend/Tudy/src/test/java/com/example/tudy/goal/GoalGroupAndDateApiTests.java
+++ b/backend/Tudy/src/test/java/com/example/tudy/goal/GoalGroupAndDateApiTests.java
@@ -74,7 +74,7 @@ public class GoalGroupAndDateApiTests {
         String endDate = LocalDate.now().plusDays(3).toString();
         // 그룹 목표 생성 (리더가 생성)
         String reqJson = "{" +
-                "\"userId\":" + leader.getId() + "," +
+                "\"userId\":\"" + leader.getUserId() + "\"," +
                 "\"title\":\"" + title + "\"," +
                 "\"categoryName\":\"" + categoryName + "\"," +
                 "\"startDate\":\"" + startDate + "\"," +
@@ -89,7 +89,7 @@ public class GoalGroupAndDateApiTests {
                 .andExpect(jsonPath("$.title").value(title));
         // 그룹원(멤버)도 같은 카테고리명으로 목표가 생성되어야 함
         mockMvc.perform(get("/api/goals")
-                .param("userId", member.getId().toString())
+                .param("userId", member.getUserId())
                 .param("categoryName", categoryName))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].title").value(title));
@@ -119,7 +119,7 @@ public class GoalGroupAndDateApiTests {
         String endDate = LocalDate.now().plusDays(2).toString();
         // 목표 생성
         String reqJson = "{" +
-                "\"userId\":" + user.getId() + "," +
+                "\"userId\":\"" + user.getUserId() + "\"," +
                 "\"title\":\"" + title + "\"," +
                 "\"categoryName\":\"" + categoryName + "\"," +
                 "\"startDate\":\"" + startDate + "\"," +
@@ -134,7 +134,7 @@ public class GoalGroupAndDateApiTests {
                 .andExpect(jsonPath("$.title").value(title));
         // 날짜별+카테고리명으로 조회
         mockMvc.perform(get("/api/goals/by-date")
-                .param("userId", user.getId().toString())
+                .param("userId", user.getUserId())
                 .param("date", startDate)
                 .param("categoryName", categoryName))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- ensure goal list endpoint uses string `userId`
- fix friend request checks to compare by `userId`
- adjust tests to send string-based `userId`
