### PR TITLE
Fix serialization of Hibernate proxies for goals

### DIFF
--- a/backend/Tudy/build.gradle
+++ b/backend/Tudy/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta'
     compileOnly 'org.projectlombok:lombok:1.18.26'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/backend/Tudy/src/main/java/com/example/tudy/category/Category.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/category/Category.java
@@ -1,6 +1,7 @@
 package com.example.tudy.category;
 
 import com.example.tudy.user.User;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
     name = "categories",
     uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "name"})
 )
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/Tudy/src/main/java/com/example/tudy/config/JacksonConfig.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/config/JacksonConfig.java
@@ -1,0 +1,14 @@
+package com.example.tudy.config;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public Module hibernate5Module() {
+        return new Hibernate5JakartaModule();
+    }
+}

--- a/backend/Tudy/src/main/java/com/example/tudy/goal/Goal.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/goal/Goal.java
@@ -2,6 +2,7 @@ package com.example.tudy.goal;
 
 import com.example.tudy.user.User;
 import com.example.tudy.category.Category;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,11 +20,13 @@ public class Goal {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     private User user;
 
     private String title;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     private Category category;
     private LocalDate startDate;
     private LocalDate endDate;

--- a/backend/Tudy/src/main/java/com/example/tudy/user/User.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/user/User.java
@@ -1,5 +1,6 @@
 package com.example.tudy.user;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Entity
 @Table(name = "users")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Summary
- add Jackson Hibernate5 module to handle lazy-loaded proxies
- ignore Hibernate proxy handlers in Goal-related entities
