### PR TITLE
Fix 500 errors for coin and building APIs

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/building/BuildingController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/building/BuildingController.java
@@ -3,9 +3,11 @@ package com.example.tudy.building;
 import com.example.tudy.user.User;
 import com.example.tudy.user.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Map;
@@ -27,7 +29,9 @@ public class BuildingController {
             @PathVariable String userId,
             @PathVariable BuildingType buildingType,
             Authentication authentication) {
-        
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         // 인증된 사용자 확인
         User authenticatedUser = userService.getUserByEmail(authentication.getName());
         User targetUser = userService.findByUserId(userId);
@@ -57,7 +61,9 @@ public class BuildingController {
             @PathVariable BuildingType buildingType,
             @PathVariable Integer slotNumber,
             Authentication authentication) {
-        
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         User authenticatedUser = userService.getUserByEmail(authentication.getName());
         User targetUser = userService.findByUserId(userId);
         
@@ -78,7 +84,9 @@ public class BuildingController {
             @PathVariable BuildingType buildingType,
             @RequestBody PurchaseRequest request,
             Authentication authentication) {
-        
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         User authenticatedUser = userService.getUserByEmail(authentication.getName());
         User targetUser = userService.findByUserId(userId);
         
@@ -104,7 +112,9 @@ public class BuildingController {
             @PathVariable Integer slotNumber,
             @RequestBody InstallRequest request,
             Authentication authentication) {
-        
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         User authenticatedUser = userService.getUserByEmail(authentication.getName());
         User targetUser = userService.findByUserId(userId);
         
@@ -129,7 +139,9 @@ public class BuildingController {
             @PathVariable BuildingType buildingType,
             @PathVariable Integer slotNumber,
             Authentication authentication) {
-        
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         User authenticatedUser = userService.getUserByEmail(authentication.getName());
         User targetUser = userService.findByUserId(userId);
         
@@ -153,7 +165,9 @@ public class BuildingController {
             @PathVariable String userId,
             @PathVariable BuildingType buildingType,
             Authentication authentication) {
-        
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         User authenticatedUser = userService.getUserByEmail(authentication.getName());
         User targetUser = userService.findByUserId(userId);
         

--- a/backend/Tudy/src/main/java/com/example/tudy/diary/GlobalExceptionHandler.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/diary/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.validation.FieldError;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
@@ -64,6 +65,16 @@ public class GlobalExceptionHandler {
         response.put("error", "잘못된 인자가 전달되었습니다");
         response.put("message", ex.getMessage());
         response.put("status", HttpStatus.BAD_REQUEST.value());
+        return response;
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, Object> handleNoSuchElement(NoSuchElementException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", "리소스를 찾을 수 없습니다");
+        response.put("message", ex.getMessage());
+        response.put("status", HttpStatus.NOT_FOUND.value());
         return response;
     }
 

--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinController.java
@@ -3,9 +3,11 @@ package com.example.tudy.game;
 import com.example.tudy.user.User;
 import com.example.tudy.user.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -22,6 +24,9 @@ public class CoinController {
      */
     @GetMapping
     public ResponseEntity<List<UserCoin>> getUserCoins(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         User user = userService.getUserByEmail(authentication.getName());
         List<UserCoin> coins = coinService.getUserCoins(user);
         return ResponseEntity.ok(coins);
@@ -34,6 +39,9 @@ public class CoinController {
     public ResponseEntity<UserCoin> getUserCoinByType(
             @PathVariable CoinType coinType,
             Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         User user = userService.getUserByEmail(authentication.getName());
         UserCoin coin = coinService.getUserCoinByType(user, coinType);
         return ResponseEntity.ok(coin);
@@ -44,6 +52,9 @@ public class CoinController {
      */
     @GetMapping("/total")
     public ResponseEntity<TotalCoinResponse> getTotalCoins(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
         User user = userService.getUserByEmail(authentication.getName());
         int totalCoins = user.getCoinBalance();
         

--- a/backend/Tudy/src/main/java/com/example/tudy/user/UserService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/user/UserService.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -179,14 +180,17 @@ public class UserService {
     }
 
     public User findById(Long id) {
-        return userRepository.findById(id).orElseThrow();
+        return userRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
     }
 
     public User findByUserId(String userId) {
-        return userRepository.findByUserId(userId).orElseThrow();
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
     }
-    
+
     public User getUserByEmail(String email) {
-        return userRepository.findByEmail(email).orElseThrow();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
     }
 }


### PR DESCRIPTION
## Summary
- Return 401 for unauthenticated access in coin and building controllers
- Map missing entities to 404 via global handler
- Throw clearer not-found exceptions from user service