### PR TITLE
Add coin betting game with daily limit

### DIFF
--- a/backend/Tudy/README_COIN_SYSTEM.md
+++ b/backend/Tudy/README_COIN_SYSTEM.md
@@ -87,6 +87,26 @@ Authorization: Bearer {token}
 }
 ```
 
+### 4. 코인 베팅 게임
+```http
+POST /api/coins/game?bet={amount}
+Authorization: Bearer {token}
+```
+
+**설명:**
+- `amount`: 베팅할 코인 수
+- 성공 시 베팅한 코인만큼 추가 획득
+- 실패 시 베팅한 코인만큼 차감
+- 하루 최대 3회까지 플레이 가능
+
+**응답:**
+```json
+{
+  "success": true,
+  "currentBalance": 120
+}
+```
+
 ## 🎯 **코인 획득 방법**
 
 ### 자동 지급 시스템

--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameAttempt.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameAttempt.java
@@ -1,0 +1,34 @@
+package com.example.tudy.game;
+
+import com.example.tudy.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "coin_game_attempts")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CoinGameAttempt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime attemptedAt;
+
+    @Column(nullable = false)
+    private Integer betAmount;
+
+    @Column(nullable = false)
+    private Boolean success;
+}

--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameAttemptRepository.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameAttemptRepository.java
@@ -1,0 +1,12 @@
+package com.example.tudy.game;
+
+import com.example.tudy.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface CoinGameAttemptRepository extends JpaRepository<CoinGameAttempt, Long> {
+    long countByUserAndAttemptedAtBetween(User user, LocalDateTime start, LocalDateTime end);
+}

--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameController.java
@@ -1,0 +1,29 @@
+package com.example.tudy.game;
+
+import com.example.tudy.user.User;
+import com.example.tudy.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/coins/game")
+@RequiredArgsConstructor
+public class CoinGameController {
+
+    private final CoinGameService coinGameService;
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<CoinGameService.CoinGameResult> playGame(@RequestParam int bet, Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
+        }
+        User user = userService.getUserByEmail(authentication.getName());
+        CoinGameService.CoinGameResult result = coinGameService.playGame(user, bet);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameService.java
@@ -1,0 +1,65 @@
+package com.example.tudy.game;
+
+import com.example.tudy.user.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CoinGameService {
+
+    private final CoinService coinService;
+    private final CoinGameAttemptRepository attemptRepository;
+    private final Random random = new Random();
+
+    public CoinGameResult playGame(User user, int betAmount) {
+        if (betAmount <= 0) {
+            throw new IllegalArgumentException("베팅 금액은 0보다 커야 합니다.");
+        }
+        if (user.getCoinBalance() < betAmount) {
+            throw new IllegalStateException("코인이 부족합니다.");
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay().minusNanos(1);
+        long attempts = attemptRepository.countByUserAndAttemptedAtBetween(user, startOfDay, endOfDay);
+        if (attempts >= 3) {
+            throw new IllegalStateException("하루 3번만 플레이할 수 있습니다.");
+        }
+
+        boolean success = random.nextBoolean();
+        if (success) {
+            coinService.addCoinsToUser(user, CoinType.ACADEMIC_SAEDO, betAmount);
+        } else {
+            coinService.subtractCoins(user, betAmount);
+        }
+
+        CoinGameAttempt attempt = new CoinGameAttempt();
+        attempt.setUser(user);
+        attempt.setAttemptedAt(LocalDateTime.now());
+        attempt.setBetAmount(betAmount);
+        attempt.setSuccess(success);
+        attemptRepository.save(attempt);
+
+        CoinGameResult result = new CoinGameResult();
+        result.setSuccess(success);
+        result.setCurrentBalance(user.getCoinBalance());
+        return result;
+    }
+
+    @Getter
+    @Setter
+    public static class CoinGameResult {
+        private boolean success;
+        private int currentBalance;
+    }
+}

--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinService.java
@@ -75,7 +75,7 @@ public class CoinService {
     /**
      * 사용자에게 코인 추가
      */
-    private void addCoinsToUser(User user, CoinType coinType, Integer amount) {
+    public void addCoinsToUser(User user, CoinType coinType, Integer amount) {
         UserCoin userCoin = userCoinRepository.findByUserAndCoinType(user, coinType)
                 .orElseGet(() -> createInitialCoin(user, coinType));
         

--- a/backend/Tudy/src/test/java/com/example/tudy/game/CoinGameServiceTest.java
+++ b/backend/Tudy/src/test/java/com/example/tudy/game/CoinGameServiceTest.java
@@ -1,0 +1,42 @@
+package com.example.tudy.game;
+
+import com.example.tudy.user.User;
+import com.example.tudy.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class CoinGameServiceTest {
+
+    @Autowired
+    private CoinGameService coinGameService;
+
+    @Autowired
+    private CoinService coinService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void limitThreeAttemptsPerDay() {
+        User user = new User();
+        user.setEmail("game@test.com");
+        user.setUserId("gameuser");
+        user.setPasswordHash("password");
+        user.setName("Game User");
+        userRepository.save(user);
+
+        coinService.addCoinsToUser(user, CoinType.ACADEMIC_SAEDO, 1000);
+
+        for (int i = 0; i < 3; i++) {
+            coinGameService.playGame(user, 10);
+        }
+
+        assertThrows(IllegalStateException.class, () -> coinGameService.playGame(user, 10));
+    }
+}


### PR DESCRIPTION
## Summary
- add coin betting API with 50/50 success and daily 3-play limit
- track betting attempts per user
- expose game endpoint and test daily limit