### PR TITLE
Prevent NPE when authentication is missing

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/auth/TokenAuthenticationFilter.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/auth/TokenAuthenticationFilter.java
@@ -7,8 +7,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
@@ -59,7 +61,22 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } catch (NoSuchElementException ignored) {
                     // 유저가 없으면 컨텍스트를 건드리지 않고 그대로 둠(비인증 상태 유지)
+                    SecurityContextHolder.getContext().setAuthentication(
+                            new AnonymousAuthenticationToken(
+                                    "anonymous",
+                                    "anonymousUser",
+                                    AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
+                            )
+                    );
                 }
+            } else {
+                SecurityContextHolder.getContext().setAuthentication(
+                        new AnonymousAuthenticationToken(
+                                "anonymous",
+                                "anonymousUser",
+                                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
+                        )
+                );
             }
         }
 

--- a/backend/Tudy/src/main/java/com/example/tudy/diary/GlobalExceptionHandler.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/diary/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.validation.FieldError;
 
 import java.util.HashMap;
@@ -75,6 +76,15 @@ public class GlobalExceptionHandler {
         response.put("error", "리소스를 찾을 수 없습니다");
         response.put("message", ex.getMessage());
         response.put("status", HttpStatus.NOT_FOUND.value());
+        return response;
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public Map<String, Object> handleResponseStatus(ResponseStatusException ex) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", ex.getReason());
+        response.put("message", ex.getReason());
+        response.put("status", ex.getStatusCode().value());
         return response;
     }
 


### PR DESCRIPTION
## Summary
- set anonymous authentication when a user token is absent to avoid null context
- add ResponseStatusException handler for proper status codes

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68ada0dd145c8322acc3bba6f6197513