### PR TITLE
Refactor coin controllers to use token-based auth

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinGameController.java
@@ -1,11 +1,11 @@
 package com.example.tudy.game;
 
+import com.example.tudy.auth.TokenService;
 import com.example.tudy.user.User;
 import com.example.tudy.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -18,31 +18,26 @@ public class CoinGameController {
 
     private final CoinGameService coinGameService;
     private final UserService userService;
+    private final TokenService tokenService;
 
     // 공통 인증 유저 조회
-    private User requireUser(Authentication authentication) {
-        if (authentication == null
-                || authentication.getPrincipal() == null
-                || !authentication.isAuthenticated()
-                || "anonymousUser".equals(authentication.getPrincipal())) {
+    private User requireUser(String authHeader) {
+        Long userId = tokenService.resolveUserId(authHeader);
+        if (userId == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
         }
 
-        String email = authentication.getName();
-        if (email == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증정보가 유효하지 않습니다.");
-        }
-
         try {
-            return userService.getUserByEmail(email);
+            return userService.findById(userId);
         } catch (NoSuchElementException e) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증정보가 유효하지 않습니다.");
         }
     }
 
     @PostMapping
-    public ResponseEntity<CoinGameService.CoinGameResult> playGame(@RequestParam int bet, Authentication authentication) {
-        User user = requireUser(authentication);
+    public ResponseEntity<CoinGameService.CoinGameResult> playGame(@RequestParam int bet,
+                                                                  @RequestHeader(value = "Authorization", required = false) String authHeader) {
+        User user = requireUser(authHeader);
         CoinGameService.CoinGameResult result = coinGameService.playGame(user, bet);
         return ResponseEntity.ok(result);
     }


### PR DESCRIPTION
## Summary
- Resolve null authentication errors in coin endpoints by deriving the user from the Authorization header instead of SecurityContext
- Apply the same token-based lookup in coin game endpoint

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68ada92aa4848322a5b3bbe314bbd436