### PR TITLE
Fix stateless token authentication with proper 401 responses

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/auth/TokenService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/auth/TokenService.java
@@ -18,12 +18,15 @@ public class TokenService {
         return token;
     }
 
-    public Long resolveUserId(String authHeader) {
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            return null;
-        }
-        String token = authHeader.substring(7);
-        if (blacklist.contains(token)) {
+    /**
+     * 토큰 문자열을 이용해 사용자 ID 를 해석한다.
+     * 잘못된 토큰이거나 블랙리스트에 등록된 토큰인 경우 null 을 반환한다.
+     *
+     * @param token UUID 기반 토큰 문자열
+     * @return 토큰에 매핑된 사용자 ID, 없으면 null
+     */
+    public Long resolveUserId(String token) {
+        if (token == null || blacklist.contains(token)) {
             return null;
         }
         return tokens.get(token);

--- a/backend/Tudy/src/main/java/com/example/tudy/config/SecurityConfig.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/config/SecurityConfig.java
@@ -4,12 +4,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import com.example.tudy.security.TokenAuthenticationFilter;
 
+import jakarta.servlet.http.HttpServletResponse;
+
 @Configuration
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -17,7 +22,15 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((request, response, authException) ->
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                .accessDeniedHandler((request, response, accessDeniedException) ->
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN))
+            )
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/api/users/login", "/api/users/signup").permitAll()
                     .anyRequest().authenticated()

--- a/backend/Tudy/src/main/java/com/example/tudy/security/TokenAuthenticationFilter.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/security/TokenAuthenticationFilter.java
@@ -32,7 +32,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         try {
             String authHeader = request.getHeader("Authorization");
             if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                Long userId = tokenService.resolveUserId(authHeader);
+                String token = authHeader.substring(7);
+                Long userId = tokenService.resolveUserId(token);
                 if (userId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
                     try {
                         User user = userService.findById(userId);


### PR DESCRIPTION
## Summary
- Parse bearer tokens in `TokenAuthenticationFilter` and populate `SecurityContext`
- Return 401/403 consistently and enforce stateless sessions in security config
- Resolve user IDs directly from token values in `TokenService`

## Testing
- `./gradlew test` *(failed: Cannot find a Java installation matching toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68adb1c4d20c832291d0d72522175059