### PR TITLE
Add JWT expiration and validation

### DIFF
--- a/backend/Tudy/src/main/resources/application.properties
+++ b/backend/Tudy/src/main/resources/application.properties
@@ -42,3 +42,4 @@ springdoc.swagger-ui.path=/swagger-ui.html
 logging.level.org.springframework.security=DEBUG
 logging.level.com.example.tudy=DEBUG
 jwt.secret=MySuperSecretJwtKeyMySuperSecretJwtKey
+jwt.expiration=3600000

--- a/backend/Tudy/src/test/java/com/example/tudy/auth/TokenServiceTest.java
+++ b/backend/Tudy/src/test/java/com/example/tudy/auth/TokenServiceTest.java
@@ -1,0 +1,30 @@
+package com.example.tudy.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "jwt.secret=testtesttesttesttesttesttesttest",
+        "jwt.expiration=3600000"
+})
+class TokenServiceTest {
+
+    @Autowired
+    TokenService tokenService;
+
+    @Test
+    void generatedTokenContainsThreePartsAndResolvesUserId() {
+        String token = tokenService.generateToken(42L);
+        assertThat(token.split("\\.")).hasSize(3);
+        Long userId = tokenService.resolveUserId(token);
+        assertThat(userId).isEqualTo(42L);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce minimum secret length and add expiration-based JWT generation
- provide configuration property `jwt.expiration`
- add unit test ensuring generated tokens are well-formed and resolvable

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation on your machine (languageVersion=17))*

------
https://chatgpt.com/codex/tasks/task_e_68aead061a788322b6dcd4035eef7e41