### PR TITLE
Enable CORS for development environment

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/config/SecurityConfig.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.tudy.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -24,6 +25,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .securityMatcher("/api/**")
+            .cors(cors -> {})
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .exceptionHandling(ex -> ex
@@ -33,6 +35,7 @@ public class SecurityConfig {
                     response.sendError(HttpServletResponse.SC_FORBIDDEN))
             )
             .authorizeHttpRequests(auth -> auth
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                     .requestMatchers("/api/users/login", "/api/users/signup").permitAll()
                     .anyRequest().authenticated()
             )


### PR DESCRIPTION
## Summary
- allow cross-origin requests by enabling CORS in the security filter chain
- permit OPTIONS requests so browsers can complete preflight checks

## Testing
- `./gradlew test` *(fails: Could not determine dependencies, Cannot find Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68aec20ac1fc83228b2684d0eeee11dd