### PR TITLE
Fix coin balance aggregation and validation

### DIFF
--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinController.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinController.java
@@ -47,13 +47,37 @@ public class CoinController {
      * 사용자의 특정 타입 코인 조회
      */
     @GetMapping("/{coinType}")
-    public ResponseEntity<UserCoin> getUserCoinByType(
-            @PathVariable CoinType coinType,
+    public ResponseEntity<CoinBalanceResponse> getUserCoinByType(
+            @PathVariable String coinType,
             Authentication authentication
     ) {
         User user = requireUser(authentication);
-        UserCoin coin = coinService.getUserCoinByType(user, coinType);
-        return ResponseEntity.ok(coin);
+
+        CoinType type;
+        try {
+            type = CoinType.valueOf(coinType);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 코인 타입입니다.");
+        }
+
+        int balance = coinService.getUserCoinBalanceByType(user, type);
+        return ResponseEntity.ok(new CoinBalanceResponse(balance));
+    }
+
+    public static class CoinBalanceResponse {
+        private int balance;
+
+        public CoinBalanceResponse(int balance) {
+            this.balance = balance;
+        }
+
+        public int getBalance() {
+            return balance;
+        }
+
+        public void setBalance(int balance) {
+            this.balance = balance;
+        }
     }
 
     /**

--- a/backend/Tudy/src/main/java/com/example/tudy/game/CoinService.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/CoinService.java
@@ -25,11 +25,10 @@ public class CoinService {
     }
     
     /**
-     * 사용자의 특정 타입 코인 조회
+     * 사용자의 특정 타입 코인 잔액 조회
      */
-    public UserCoin getUserCoinByType(User user, CoinType coinType) {
-        return userCoinRepository.findByUserAndCoinType(user, coinType)
-                .orElseGet(() -> createInitialCoin(user, coinType));
+    public int getUserCoinBalanceByType(User user, CoinType coinType) {
+        return userCoinRepository.sumAmountByUserAndCoinType(user, coinType);
     }
     
     /**
@@ -94,12 +93,10 @@ public class CoinService {
      * 사용자에게 코인 추가
      */
     public void addCoinsToUser(User user, CoinType coinType, Integer amount) {
-        UserCoin userCoin = userCoinRepository.findByUserAndCoinType(user, coinType)
-                .orElseGet(() -> createInitialCoin(user, coinType));
-        
+        UserCoin userCoin = new UserCoin(user, coinType);
         userCoin.addAmount(amount);
         userCoinRepository.save(userCoin);
-        
+
         // User의 coinBalance도 업데이트 (모든 코인 종류의 합계)
         updateUserTotalCoinBalance(user);
     }
@@ -139,11 +136,4 @@ public class CoinService {
         };
     }
     
-    /**
-     * 초기 코인 생성
-     */
-    private UserCoin createInitialCoin(User user, CoinType coinType) {
-        UserCoin userCoin = new UserCoin(user, coinType);
-        return userCoinRepository.save(userCoin);
-    }
 }

--- a/backend/Tudy/src/main/java/com/example/tudy/game/UserCoinRepository.java
+++ b/backend/Tudy/src/main/java/com/example/tudy/game/UserCoinRepository.java
@@ -2,17 +2,17 @@ package com.example.tudy.game;
 
 import com.example.tudy.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface UserCoinRepository extends JpaRepository<UserCoin, Long> {
     
     List<UserCoin> findByUser(User user);
-    
-    Optional<UserCoin> findByUserAndCoinType(User user, CoinType coinType);
-    
-    boolean existsByUserAndCoinType(User user, CoinType coinType);
+
+    @Query("SELECT COALESCE(SUM(uc.amount), 0) FROM UserCoin uc WHERE uc.user = :user AND uc.coinType = :coinType")
+    int sumAmountByUserAndCoinType(@Param("user") User user, @Param("coinType") CoinType coinType);
 }

--- a/backend/Tudy/src/test/java/com/example/tudy/game/CoinServiceLedgerTest.java
+++ b/backend/Tudy/src/test/java/com/example/tudy/game/CoinServiceLedgerTest.java
@@ -1,0 +1,46 @@
+package com.example.tudy.game;
+
+import com.example.tudy.user.User;
+import com.example.tudy.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+class CoinServiceLedgerTest {
+
+    @Autowired
+    private CoinService coinService;
+
+    @Autowired
+    private UserCoinRepository userCoinRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void getUserCoinBalanceByType_sumsLedgerEntries() {
+        User user = new User();
+        user.setEmail("ledger@test.com");
+        user.setUserId("ledgeruser");
+        user.setPasswordHash("password");
+        user.setName("Ledger User");
+        userRepository.save(user);
+
+        UserCoin first = new UserCoin(user, CoinType.CAFE);
+        first.setAmount(30);
+        userCoinRepository.save(first);
+
+        UserCoin second = new UserCoin(user, CoinType.CAFE);
+        second.setAmount(20);
+        userCoinRepository.save(second);
+
+        int balance = coinService.getUserCoinBalanceByType(user, CoinType.CAFE);
+        assertEquals(50, balance);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Sum ledger entries for user coin balances to prevent non-unique errors
- Return balance integer and handle invalid coin types in coin controller
- Store coin additions as separate ledger entries and add ledger sum test

## Testing
- `./gradlew test` *(fails: Could not resolve all dependencies for configuration ':testRuntimeClasspath'. Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68aee7b0d79c8322b8d0c3b31d424b68